### PR TITLE
Feat: added close settings button 'x'

### DIFF
--- a/components/sidebar.tsx
+++ b/components/sidebar.tsx
@@ -50,7 +50,16 @@ export default function SettingsSidebar({ isOpen, onClose, onColorChange, curren
                 ref={sidebarRef}
             >
                 <div className="p-6">
-                    <h2 className="text-xl font-bold mb-6">Settings</h2>
+                    <div className="flex justify-between items-center mb-6">
+                        <h2 className="text-xl font-bold">Settings</h2>
+                        <button 
+                            onClick={onClose}
+                            className="w-8 h-8 flex items-center justify-center rounded-full hover:bg-zinc-800 transition-colors"
+                            aria-label="Close settings"
+                        >
+                            <span className="text-xl font-medium">×</span>
+                        </button>
+                    </div>
                     <div className="space-y-6">
                         <div className="block">
                             <span className="block mb-3">Background Color</span>


### PR DESCRIPTION
Added a new feature where you can now close the settings by clicking the x on the top right (in addition to clicking outside the pane on desktop). This feature is mainly targeting mobile devices. See the changes below (note the top right of page):

**Before:** 
![image](https://github.com/user-attachments/assets/30cd07f1-4f44-4cc0-81f2-33642d73707e)
**After:** 
![image](https://github.com/user-attachments/assets/e3a0a913-546c-4cc9-b994-5d06de390d56)
