### PR TITLE
Fix: timer continues to run even if tab not focused

### DIFF
--- a/components/timer.tsx
+++ b/components/timer.tsx
@@ -67,7 +67,7 @@ const Timer: React.FC<TimerProps> = ({ time, active, resetKey, isDark }) => {
         }
 
         return () => {
-            if (animationFrameId) {
+            if (animationFrameId !== undefined) {
                 cancelAnimationFrame(animationFrameId);
             }
         };


### PR DESCRIPTION
Prev, if you started the timer, switching tabs would let the timer run for a couple of seconds, then pause. Now, the timer will continue to run until it reaches 00:00, even if in a different tab.